### PR TITLE
API Changes for Blender 5.2 LTS

### DIFF
--- a/hair_tools/make_hair.py
+++ b/hair_tools/make_hair.py
@@ -1014,17 +1014,29 @@ class DAZ_OT_MakeHair(MatchOperator, CombineHair, IsMesh, HairOptions, HairBuild
                     return mod
 
             mod = addMod(ob, "Set Hair Curve Profile")
-            if mod:
-                socket = ("Input" if "Input_2" in mod.keys() else "Socket")
-                mod["%s_3" % socket] = self.hairRadius * 1e-3
-                mod["%s_2" % socket] = self.hairShape
-            if len(strands) < self.childThreshold and self.nRenderChildren > 0:
-                mod = addMod(ob, "Duplicate Hair Curves")
+            
+            if bpy.app.version >= (5,2,0):
+                if mod:
+                    getattr(mod.properties.inputs, "Input_3").value = self.hairRadius * 1e-3
+                    getattr(mod.properties.inputs, "Input_2").value = self.hairShape
+                if len(strands) < self.childThreshold and self.nRenderChildren > 0:
+                    mod = addMod(ob, "Duplicate Hair Curves")
+                    if mod:
+                        getattr(mod.properties.inputs, "Input_2").value = self.nRenderChildren
+                        getattr(mod.properties.inputs, "Input_4").value = self.viewFactor
+                        getattr(mod.properties.inputs, "Input_5").value = self.childRadius * 1e-3
+            else:
                 if mod:
                     socket = ("Input" if "Input_2" in mod.keys() else "Socket")
-                    mod["%s_2" % socket] = self.nRenderChildren
-                    mod["%s_4" % socket] = self.viewFactor
-                    mod["%s_5" % socket] = self.childRadius * 1e-3
+                    mod["%s_3" % socket] = self.hairRadius * 1e-3
+                    mod["%s_2" % socket] = self.hairShape
+                if len(strands) < self.childThreshold and self.nRenderChildren > 0:
+                    mod = addMod(ob, "Duplicate Hair Curves")
+                    if mod:
+                        socket = ("Input" if "Input_2" in mod.keys() else "Socket")
+                        mod["%s_2" % socket] = self.nRenderChildren
+                        mod["%s_4" % socket] = self.viewFactor
+                        mod["%s_5" % socket] = self.childRadius * 1e-3
 
     def findMeshRects(self, hair):
         from ..tables import getVertFaces, findNeighbors

--- a/hair_tools/make_hair.py
+++ b/hair_tools/make_hair.py
@@ -1017,14 +1017,14 @@ class DAZ_OT_MakeHair(MatchOperator, CombineHair, IsMesh, HairOptions, HairBuild
             
             if bpy.app.version >= (5,2,0):
                 if mod:
-                    getattr(mod.properties.inputs, "Input_3").value = self.hairRadius * 1e-3
-                    getattr(mod.properties.inputs, "Input_2").value = self.hairShape
+                    mod.properties.inputs.Input_3.value = self.hairRadius * 1e-3
+                    mod.properties.inputs.Input_2.value = self.hairShape
                 if len(strands) < self.childThreshold and self.nRenderChildren > 0:
                     mod = addMod(ob, "Duplicate Hair Curves")
                     if mod:
-                        getattr(mod.properties.inputs, "Input_2").value = self.nRenderChildren
-                        getattr(mod.properties.inputs, "Input_4").value = self.viewFactor
-                        getattr(mod.properties.inputs, "Input_5").value = self.childRadius * 1e-3
+                        mod.properties.inputs.Input_2.value = self.nRenderChildren
+                        mod.properties.inputs.Input_4.value = self.viewFactor
+                        mod.properties.inputs.Input_5.value = self.childRadius * 1e-3
             else:
                 if mod:
                     socket = ("Input" if "Input_2" in mod.keys() else "Socket")


### PR DESCRIPTION
[The API for accessing Geometry Nodes modifier properties has changed.](https://developer.blender.org/docs/release_notes/5.2/python_api/#geometry-nodes)

Blender 5.2 has breaking change and geo nodes has to be accessed via RNA properties->inputs