### PR TITLE
Fix geograft capture output in Blender 5.2

### DIFF
--- a/geonodes.py
+++ b/geonodes.py
@@ -40,7 +40,7 @@ class GeoTree(Tree, NodeGroup):
             self.links.new(fromsocket, node.inputs[-2])
 
         def captureOutput(self, node, slot, tosocket):
-            self.links.new(node.outputs[1], tosocket)
+            self.links.new(node.outputs["Value"], tosocket)
 
 # ---------------------------------------------------------------------
 #   Geograft group


### PR DESCRIPTION
Fixes #54.

Blender 5.2 added a `Selection` output to Capture Attribute, so output index 1 no longer points to `Value`. That sent selection fields into the geograft position calculation and collapsed baked grafts.

Use the socket name instead of its position.

Tested with baked geografts in Blender 5.1.2 and 5.2.0.
